### PR TITLE
Add X & Y invert axis options

### DIFF
--- a/octoprint_zbolt_octoscreen/__init__.py
+++ b/octoprint_zbolt_octoscreen/__init__.py
@@ -79,6 +79,7 @@ class ZBoltOctoScreenPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "Z-Bolt OctoScreen"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
     global __plugin_implementation__    

--- a/octoprint_zbolt_octoscreen/settings.py
+++ b/octoprint_zbolt_octoscreen/settings.py
@@ -92,6 +92,8 @@ class ZBoltOctoScreenSettings(object):
             "filament_out_length": float(self._settings.get(["filament_out_length"])),
             "gcodes": self._settings.get(["gcodes"]),
             "toolchanger": bool(self._settings.get(["toolchanger"])),
+            "x_axis_inverted": bool(self._settings.get(["x_axis_inverted"])),
+            "y_axis_inverted": bool(self._settings.get(["y_axis_inverted"])),
             "z_axis_inverted": bool(self._settings.get(["z_axis_inverted"])),
             "menu_structure": json.loads(self._settings.get(["menu_structure"])),
         }
@@ -102,6 +104,8 @@ class ZBoltOctoScreenSettings(object):
             filament_in_length=750,
             filament_out_length=800,
             toolchanger=False,
+            x_axis_inverted=False,
+            y_axis_inverted=False,
             z_axis_inverted=True,
             gcodes=dict(auto_bed_level="G29"),
             menu_structure=default_menu_structure,

--- a/octoprint_zbolt_octoscreen/templates/zbolt_octoscreen_settings.jinja2
+++ b/octoprint_zbolt_octoscreen/templates/zbolt_octoscreen_settings.jinja2
@@ -45,6 +45,20 @@
                 <h4>{{ _('Other:') }}</h4>
 
                 <div class="control-group">
+                    <label class="control-label">{{ _('Invert X axis buttons on move screen:') }}</label>
+                    <div class="controls">
+                        <input type="checkbox" data-bind="checked: settings.plugins.zbolt_octoscreen.x_axis_inverted" />
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label">{{ _('Invert Y axis buttons on move screen:') }}</label>
+                    <div class="controls">
+                        <input type="checkbox" data-bind="checked: settings.plugins.zbolt_octoscreen.y_axis_inverted" />
+                    </div>
+                </div>
+
+                <div class="control-group">
                     <label class="control-label">{{ _('Invert Z axis buttons on move screen:') }}</label>
                     <div class="controls">
                         <input type="checkbox" data-bind="checked: settings.plugins.zbolt_octoscreen.z_axis_inverted" />


### PR DESCRIPTION
UI options for https://github.com/Z-Bolt/OctoScreen/pull/176.

PS: I also made this plugin [compatible with Octoprint + Python3](https://docs.octoprint.org/en/master/plugins/python3_migration.html#telling-octoprint-your-plugin-is-python-3-ready).